### PR TITLE
Corrected range of motion for clock (140º –> 160º)

### DIFF
--- a/fow-mini/lib/fow/ServoClockOutputManager.h
+++ b/fow-mini/lib/fow/ServoClockOutputManager.h
@@ -35,8 +35,8 @@ class ServoClockOutputManager : public OutputManagerInterface {
     void update(std::function<DataManager::FerryData (int)> dataSupplier);
     void calibrate();
   private:
-    const int servoMaxPosition = 160;
-    const int servoMinPosition = 20;
+    const int servoMaxPosition = 170;
+    const int servoMinPosition = 10;
     const int lightIntensity = 5;
     const int dockLightIntensity = 255;
     const int departingDockLightPin = 2;


### PR DESCRIPTION
Indicator hand driven by servo motor should now operate within range extents per engraved graphics.